### PR TITLE
[FIX] Homebrew package site link

### DIFF
--- a/content/public/general/downloads.md
+++ b/content/public/general/downloads.md
@@ -18,7 +18,7 @@ The last version that is guaranteed to work on Windows XP is 0.89. You can downl
 
  **Mac**
 
-[Homebrew package](https://github.com/Homebrew/homebrew-core/blob/master/Formula/ccextractor.rb)
+[Homebrew package](https://github.com/Homebrew/homebrew-core/blob/master/Formula/c/ccextractor.rb)
 (3rd party, not maintained by the CCExtractor team)
 
 **Package managers**


### PR DESCRIPTION
Fix #39 by adding [correct link](https://github.com/Homebrew/homebrew-core/blob/master/Formula/c/ccextractor.rb) of Homebrew package

Addresses [Issue 1580](https://github.com/CCExtractor/ccextractor/issues/1580)