### PR TITLE
Added Corrected Docs Link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,7 +15,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 [[menu.main]]
   name = "Docs"
   weight = 2
-  url = "docs/"
+  url = "docs/cchome"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
Fixes issue #44
The link to docs was redirecting to the same page, updated to docs/cchome to redirect to docs page

@cfsmp3, could you please review this PR