### PR TITLE
correct Indian time & add Sydney time for sunday meetings.

### DIFF
--- a/content/docs/ideas_page_for_summer_of_code_2024.md
+++ b/content/docs/ideas_page_for_summer_of_code_2024.md
@@ -23,7 +23,9 @@ Start date (tentative):
 
 Hours:
 Sundays at 8:30 AM PDT -7:00 hours (Pacific Daylight Time)
-which is 17:30 in Central Europe (until the clock changes there) and 10 PM in India.\n-3:30 AM (Monday - the next day) in Sydney, Australia.
+which is 17:30 in Central Europe (until the clock changes there) and 10 PM in India.
+
+\\n- 3:30 AM (Monday - the next day) in Sydney, Australia.
 
 (use San francisco Time for "official clock" - 8:30 AM in San Francisco is what matters, if you want to add your local time here send a pull request).
 

--- a/content/docs/ideas_page_for_summer_of_code_2024.md
+++ b/content/docs/ideas_page_for_summer_of_code_2024.md
@@ -23,8 +23,7 @@ Start date (tentative):
 
 Hours:
 Sundays at 8:30 AM PDT -7:00 hours (Pacific Daylight Time)
-which is 17:30 in Central Europe (until the clock changes there) and 10 PM in India.
-3:30 AM (Monday - the next day) in Sydney, Australia.
+which is 17:30 in Central Europe (until the clock changes there) and 10 PM in India.\n-3:30 AM (Monday - the next day) in Sydney, Australia.
 
 (use San francisco Time for "official clock" - 8:30 AM in San Francisco is what matters, if you want to add your local time here send a pull request).
 

--- a/content/docs/ideas_page_for_summer_of_code_2024.md
+++ b/content/docs/ideas_page_for_summer_of_code_2024.md
@@ -23,9 +23,9 @@ Start date (tentative):
 
 Hours:
 Sundays at 8:30 AM PDT -7:00 hours (Pacific Daylight Time)
-which is 17:30 in Central Europe (until the clock changes there) and 10 PM in India.
-
-\\n- 3:30 AM (Monday - the next day) in Sydney, Australia.
+which is 17:30 in Central Europe (until the clock changes there) and 10 PM in India.  
+- 3:30 AM (Monday - the next day) in Sydney, Australia.
+- or use [this link](https://dateful.com/convert/pst-pdt-pacific-time?t=0830) to automatically convert the meeting time to your local timezone.
 
 (use San francisco Time for "official clock" - 8:30 AM in San Francisco is what matters, if you want to add your local time here send a pull request).
 

--- a/content/docs/ideas_page_for_summer_of_code_2024.md
+++ b/content/docs/ideas_page_for_summer_of_code_2024.md
@@ -23,7 +23,8 @@ Start date (tentative):
 
 Hours:
 Sundays at 8:30 AM PDT -7:00 hours (Pacific Daylight Time)
-which is 17:30 in Central Europe (until the clock changes there) and 9 PM in India.
+which is 17:30 in Central Europe (until the clock changes there) and 10 PM in India.
+3:30 AM (Monday - the next day) in Sydney, Australia.
 
 (use San francisco Time for "official clock" - 8:30 AM in San Francisco is what matters, if you want to add your local time here send a pull request).
 


### PR DESCRIPTION
Indian Time changed from 9 PM to 10 PM.
Sydney Time added.