### PR TITLE
Update sydney time zone

### DIFF
--- a/content/docs/ideas_page_for_summer_of_code_2024.md
+++ b/content/docs/ideas_page_for_summer_of_code_2024.md
@@ -24,7 +24,7 @@ Start date (tentative):
 Hours:
 Sundays at 8:30 AM PDT -7:00 hours (Pacific Daylight Time)
 which is 16:30 in Central Europe (until the clock changes there) and 9 PM in India.  
-- 2:30 AM (Monday - the next day) in Sydney, Australia.
+- 1:30 AM (Monday - the next day) in Sydney, Australia.
 - (Better way) - use [this link](https://dateful.com/convert/pst-pdt-pacific-time?t=0830) to automatically convert the meeting time to your local timezone.  
 <br>
 


### PR DESCRIPTION
Update sydney timezone to accommodate daylight savings ending.