### PR TITLE
Migrate to zulip

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -26,11 +26,11 @@ CCExtractor Development is an informal (meaning we're not incorporated anywhere)
     
 
 {{< tip "warning" >}}
-This website is still in beta, you might come across formatting errors or pages not found. Please report them on slack.    
+This website is still in beta, you might come across formatting errors or pages not found. Please report them on Zulip.    
 {{< /tip >}}
 
 {{< tip >}}
-To get in touch with us, join our slack channel. Most CCExtractor developers hang out in a slack team. You're welcome to request an invitation [here](/public//general/support/)
+To get in touch with us, join our Zulip instance. Most CCExtractor developers hang out on our Zulip space. You're welcome to request an invitation [here](/public//general/support/)
 
 {{< /tip >}}
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -14,11 +14,11 @@ CCExtractor Development is an informal (meaning we're not incorporated anywhere)
     
 
 {{< tip "warning" >}}
-This website is still in beta, you might come across formatting errors or pages not found. Please report them on slack.    
+This website is still in beta, you might come across formatting errors or pages not found. Please report them on Zulip.    
 {{< /tip >}}
 
 {{< tip >}}
-To get in touch with us, join our slack channel. Most CCExtractor developers hang out in a slack team. You're welcome to request an invitation [here](/public//general/support/)
+To get in touch with us, join our Zulip instance. Most CCExtractor developers hang out on Zulip. You're welcome to request an invitation [here](/public//general/support/)
 
 {{< /tip >}}
 

--- a/content/docs/ideas_page_for_summer_of_code_2025.md
+++ b/content/docs/ideas_page_for_summer_of_code_2025.md
@@ -38,9 +38,7 @@ We will start at 8:30 and stay around for at least for 30 minutes, so you can sh
 {{< /tip >}} 
 
 
-Welcome to our ideas page. It's great you want to start early. Please
-join us in our slack channel! (we'll leave this as an exercise for you to
-find --- it's on our website).
+Welcome to our ideas page. It's great you want to start early. Please join us in our Zulip space! (we'll leave this as an exercise for you to find --- it's on our website).
 
 As you will see, this year has a lot of Rust. The reason is simple:
 Security. Our C code base has known (and we suspect, a lot of unknown)

--- a/content/docs/ideas_page_for_summer_of_code_2025.md
+++ b/content/docs/ideas_page_for_summer_of_code_2025.md
@@ -121,16 +121,16 @@ October.
 
 We have *mentors all over the world* (North America, Europe, Asia and
 Australia), so time zones are never a problem. Our main channel of
-communication is a [Slack channel](/public/general/support) to
+communication is a [Zulip instance](/public/general/support) to
 which everyone is welcome. We expect all accepted students to be
-available on Slack very often, even if you don't need to talk to your
+available on Zulip very often, even if you don't need to talk to your
 mentor. This will help you ask questions when necessary, and you might
 be able to help others out as well while working on your project.
 
-Exception: If your country (such as **Russia**) has banned Slack please get in touch in we'll work out a solution with you. We absolutely want you to participate.
+Exception: If your country (such as **Russia**) has banned Zulip please get in touch in we'll work out a solution with you. We absolutely want you to participate.
 
 A [mailing list](https://groups.google.com/forum/#!forum/ccextractor-dev)
-is also available for those that prefer email over Slack. Note that getting replies might be faster on Slack though.
+is also available for those that prefer email over Zulip. Note that getting replies might be faster on Zulip though (and it should be just as organized!).
 
 **All our top committers will be mentoring**. Many of them are former GSoC students or winners of GCI.
 
@@ -278,7 +278,7 @@ It goes without saying that everyone in the community has to be polite
 and respectful, and consider everyone else a member of a team and not a
 competitor.
 
-All developers are part of the team, by the way. Our Slack channel has
+All developers are part of the team, by the way. Our Zulip instance has
 mentors, code-in participants, other students, or developers and users
 that are none of the above but they all play some kind of role in
 CCExtractor's community.
@@ -288,8 +288,8 @@ time. Most of us have day jobs, and as such are limited in the time we
 can use to guide you. We'd like to spend it on quality discussions, and
 not on things that are for example written on this website, things that
 you can easily retrieve by reading documentation on used libraries or on
-the software's help screen. Asking this kind of questions in the Slack
-channel shows little respect for our time. This doesn't mean you can't
+the software's help screen. Asking this kind of questions in the Zulip
+instance shows little respect for our time. This doesn't mean you can't
 ask questions, but remember that being a clueless user and a lazy
 developer are two very different things. If you ask those questions you
 will probably get an answer as if you were a clueless user (polite no

--- a/content/public/general/flutter_gui.md
+++ b/content/public/general/flutter_gui.md
@@ -76,6 +76,6 @@ The GUI has tons of options so they are seperated into several settings screens.
 
 
 {{< tip >}}
-To report any bugs, please file a issue on github or get in touch with us on slack. Most CCExtractor developers hang out in a slack team. You're welcome to request an invitation [here](/public/general/support/)
+To report any bugs, please file a issue on github or get in touch with us on Zulip. Most CCExtractor developers hang out on Zulip. You're welcome to request an invitation [here](/public/general/support/)
 
 {{< /tip >}}

--- a/content/public/general/support.md
+++ b/content/public/general/support.md
@@ -1,9 +1,9 @@
 ---
-title: "Slack"
+title: "Zulip"
 ---
 
-Slack is a great communication tool. Most CCExtractor developers hang
-out in a slack team. You're welcome to join our Slack channel through the following [invite link](https://join.slack.com/t/rhccgsoc15/shared_invite/zt-2nctzggkl-7yOW7vIm3vL2K~yUlgm6aA) . If the link no longer works (it has some limits), send an email to the mail address at the bottom of this page and we'll update it ASAP.
+Our primary means of communication is through Zulip chat. This space is where you'll find most of CCExtractor's developers, old GSoC contributors and so on.
+You're welcome to join our Zulip community through the following [invite link](https://ccextractor.zulipchat.com/join/7n3sxaevqfizv75p6hekhxqe/). If the link no longer works (it has some limits), send an email to the mail address at the bottom of this page and we'll update it ASAP.
 
 
 ### Technical issues
@@ -28,7 +28,7 @@ When creating a ticket:
 We do have a mailing list available [here](https://groups.google.com/forum/#!forum/ccextractor-dev), and all
 issues can be found back [on our GitHub](https://github.com/CCExtractor/ccextractor/issues).
 
-It's read by the right people; you can use it if you prefer it to Slack.
+It's read by the right people; you can use it if you prefer it to Zulip.
 
 ### Email
 


### PR DESCRIPTION
Replace all the use of Slack with Zulip and replace the invite link.