### PR TITLE
Fixed errors due to unmaintained theme fork

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,7 @@ title = "CCExtractor"
 enableRobotsTXT = true
 # this example loads the theme as hugo module
 # comment out line below, and uncomment the line after it if you prefer to load the theme normally
-theme = ["github.com/Techno-Disaster/compose"] # edit this if you'ld rather use a fork of this repo
+theme = ["github.com/onweru/compose"]
 # theme = "compose"
 enableGitInfo = true
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module compose-exampleSite
 
 go 1.15
 
-require github.com/Techno-Disaster/compose v0.0.0-20220203195411-fe432ab9dec7 // indirect
+require (
+	github.com/onweru/compose v0.0.0-20250123191918-095317e5c72c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/Techno-Disaster/compose v0.0.0-20220203195411-fe432ab9dec7 h1:IBfIeHVTKXSOQeGO4fEz2x5ZJjoRIf9GTdUYTT85/7c=
-github.com/Techno-Disaster/compose v0.0.0-20220203195411-fe432ab9dec7/go.mod h1:4UviMFFVBlNSClOr/ZFfKJl2yAM7MeJ6jZCsy2bbatg=
+github.com/onweru/compose v0.0.0-20250123191918-095317e5c72c h1:7yWUB0saRkxfw5sSaQF9/sRegrcCZnwV3pFi2YI3RxU=
+github.com/onweru/compose v0.0.0-20250123191918-095317e5c72c/go.mod h1:2eSBLsKzvKf3r4/vHiKdakIBqDtWACDAqAD7tRdt00o=


### PR DESCRIPTION
There were certain errors due to using the [unmaintained fork](https://github.com/techno-disaster/compose) of the theme. Switch the theme to the [parent repository](https://github.com/onweru/compose) which is maintained.

---

## Fixes #69 

