### PR TITLE
fix: broken task link in taskwarrior page

### DIFF
--- a/content/public/gsoc/2025/taskwarrior.md
+++ b/content/public/gsoc/2025/taskwarrior.md
@@ -184,7 +184,7 @@ Here’s the preferred tech stack:
 
 ## 📜 **Ready to Contribute?**
 
-👉 **[Start the Qualification Task](https://ccextractor.org/gsoc/takehome)**
+👉 **[Start the Qualification Task](https://ccextractor.org/public/gsoc/takehome)**
 
 💬 **Questions?**  
 Put your questions in Zulip.


### PR DESCRIPTION
The take home task link in taskwarrior page was broken. Fixed it.