### PR TITLE
Fix broken links for Subtitle Downloader and Activity Extractor docum…

### DIFF
--- a/content/public/general/downloads.md
+++ b/content/public/general/downloads.md
@@ -25,9 +25,9 @@ As far as we know, CCExtractor is available on the following package managers (i
 
  **Additional software written by the team**
 
-[ User Documentation for Subtitle Downloader ](http://www.ccextractor.org/doku.php?id=public/gsoc/repository_documentation)
+[ User Documentation for Subtitle Downloader ](/public/gsoc/2016/abishek/subtitle_downloader/)
 
-[ User Documentation for Activity Extractor ](http://www.ccextractor.org/doku.php?id=public/codein/activity_extractor_user_docs)
+[ User Documentation for Activity Extractor ](/public/codein/activity_extractor_user_docs/)
 
 [CCAligner - Word by Word Audio Subtitle Synchronisation Tool and API](/public/gsoc/2017/saurabh)
 


### PR DESCRIPTION
This PR updates two broken links in the **Downloads** section of the CCExtractor website. This should resolve the issue [#1654 issue](https://github.com/CCExtractor/ccextractor/issues/1654)

User Documentation for Subtitle Downloader
Updated to: /public/gsoc/2016/abishek/subtitle_downloader/
User Documentation for Activity Extractor
Updated to: /public/codein/activity_extractor_user_docs/
