### PR TITLE
taskwarrior_flutter: redirects to public pages of taskwarrior flutter

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1777,3 +1777,15 @@ HUGO_ENABLEGITINFO = "true"
   to = "/public/gsoc/flutter-more-clients" 
   status = 301 
   force = true
+  
+[[redirects]]
+  from = "/projects/tw_f/fdroid/repo" 
+  to = "https://ccextractor.github.io/taskwarrior-flutter/repo/" 
+  status = 301 
+  force = true
+
+[[redirects]]
+  from = "/projects/tw_f/" 
+  to = "https://ccextractor.github.io/taskwarrior-flutter/" 
+  status = 301 
+  force = true


### PR DESCRIPTION
these are short urls for taskwarrior flutter pages hosted on github poges

- [x] checked the netlify deploy preview 

https://deploy-preview-90--ccextractor-website.netlify.app/projects/tw_f
https://deploy-preview-90--ccextractor-website.netlify.app/projects/tw_f/fdroid/repo
