### PR TITLE
Fix: Faulty Qualification Task link in taskserver.md

### DIFF
--- a/content/public/gsoc/2026/taskserver.md
+++ b/content/public/gsoc/2026/taskserver.md
@@ -140,7 +140,7 @@ All features described below are part of the same project and are expected to be
 
 ## 📜 **Ready to Contribute?**
 
-👉 **[Start the Qualification Task](https://ccextractor.org/gsoc/takehome)**
+👉 **[Start the Qualification Task](https://ccextractor.org/public/gsoc/takehome)**
 
 💬 **Questions?**
 Put your questions in Zulip.


### PR DESCRIPTION
Previous link for qualification task was pointing towards "https://ccextractor.org/gsoc/takehome/" instead of "https://ccextractor.org/public/gsoc/takehome/" resulting in error code 404
Fixes #117 